### PR TITLE
enable "GstVideo" introspection

### DIFF
--- a/lib/GStreamer1.pm
+++ b/lib/GStreamer1.pm
@@ -47,7 +47,7 @@ BEGIN {
         #'Rtsp',
         #'Sdp',
         #'Tag',
-        #'Video',
+        'Video',
     )) {
         my $basename = 'Gst' . $name;
         my $pkg      = $name


### PR DESCRIPTION
This is necessary to make X overlays work. E.g.:

``` perl
my $sink = GStreamer1::ElementFactory::make(xvimagesink => 'overlay');
$sink->set_window_handle($gtk_widget->window->get_xid);
```

I'm fairly new to the gobject introspection stuff. So I don't know if this could possibly create other problems, but it _seems_ to just work out of the box.
